### PR TITLE
lesson overview bar includes percentage

### DIFF
--- a/frontend/src/components/LessonOverview.jsx
+++ b/frontend/src/components/LessonOverview.jsx
@@ -38,6 +38,8 @@ const LessonOverview = () => {
         ); 
     }
 
+    const percentage = (completedExercises / lesson.exercises.length) * 100;
+
     return (
         <View style={theme.blueContainer}>
             <Animated.View style={[theme.whiteContainerInLessonOverview, { transform: [{ translateX: slideAnim }] }]}>
@@ -50,7 +52,8 @@ const LessonOverview = () => {
                             You got {completedExercises} out of {lesson.exercises.length} right!
                         </Text>
                         <View style={theme.pillBar}>
-                            <View style={[theme.pillBarFill, { width: (completedExercises / lesson.exercises.length) * 100 + '%' }]}>
+                            <View style={[theme.pillBarFill, { width: percentage + '%' }]}>
+                                <Text style={theme.LessonOverviewPercentage}>{percentage}%</Text>
                             </View>
                         </View>
                     </View>

--- a/frontend/src/themes/LessonOverviewTheme.js
+++ b/frontend/src/themes/LessonOverviewTheme.js
@@ -41,6 +41,17 @@ const theme = {
         fontFamily: "AlfaSlabOne",
         lineHeight: 24,
       },
+
+      LessonOverviewPercentage: {
+        color: "rgba(75,113,123,1)",
+        fontSize: 18,
+        textAlign: "center",
+        paddingVertical: 10,
+        fontFamily: "AlfaSlabOne",
+        lineHeight: 24,
+        opacity: 0.8,
+      },
+
       pillBar: {
         borderWidth: 3,
         borderRadius: 25,


### PR DESCRIPTION
opacity is at 0.8, could be changed if it doesn't look good

Current implementation pictured below:
![image](https://github.com/user-attachments/assets/078b2091-4851-4ac2-bc8e-cfc70cfcc79e)
